### PR TITLE
RUBY-3232 Bump toolchain version

### DIFF
--- a/share/Dockerfile.erb
+++ b/share/Dockerfile.erb
@@ -13,7 +13,7 @@ server_archive_basename = File.basename(server_url)
 server_extracted_dir = server_archive_basename.sub(/\.(tar\.gz|tgz)$/, '')
 
 # When changing, also update the hash in shlib/set_env.sh.
-TOOLCHAIN_VERSION='13d86a9123760ce13075125c5bd9d68ddb992a28'
+TOOLCHAIN_VERSION='dddbb3044addd39bf4a3515d84dc1309fb863728'
 
 def ruby_toolchain_url(ruby)
   "http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/#{TOOLCHAIN_VERSION}/#{distro}/#{ruby}.tar.xz"

--- a/shlib/set_env.sh
+++ b/shlib/set_env.sh
@@ -1,5 +1,5 @@
 # When changing, also update the hash in share/Dockerfile.
-TOOLCHAIN_VERSION=13d86a9123760ce13075125c5bd9d68ddb992a28
+TOOLCHAIN_VERSION=dddbb3044addd39bf4a3515d84dc1309fb863728
 
 set_env_java() {
   ls -l /opt || true


### PR DESCRIPTION
The toolchain had to be rebuilt to accommodate a new preferred host distro (see https://github.com/10gen/mongo-ruby-toolchain/pull/41).