### PR TITLE
RUBY 3232 tweaks for supporting updated build hosts

### DIFF
--- a/lib/mrss/server_version_registry.rb
+++ b/lib/mrss/server_version_registry.rb
@@ -25,11 +25,9 @@ module Mrss
     attr_reader :desired_version, :arch
 
     def target_arch
-      @target_arch ||= case RbConfig::CONFIG["arch"]
-        when /aarch/ then "aarch64"
-        when /x86/   then "x86_64"
-        else raise "unsupported architecture:#{RbConfig::CONFIG["arch"]}"
-        end
+      # can't use RbConfig::CONFIG["arch"] because JRuby doesn't
+      # return anything meaningful there.
+      @target_arch ||= `uname -p`.strip
     end
 
     def download_url

--- a/lib/mrss/server_version_registry.rb
+++ b/lib/mrss/server_version_registry.rb
@@ -24,6 +24,14 @@ module Mrss
 
     attr_reader :desired_version, :arch
 
+    def target_arch
+      @target_arch ||= case RbConfig::CONFIG["arch"]
+        when /aarch/ then "aarch64"
+        when /x86/   then "x86_64"
+        else raise "unsupported architecture:#{RbConfig::CONFIG["arch"]}"
+        end
+    end
+
     def download_url
       @download_url ||= begin
         version, version_ok = detect_version(current_catalog)
@@ -40,7 +48,7 @@ module Mrss
         end
         dl = version['downloads'].detect do |dl|
           dl['archive']['url'].index("enterprise-#{arch}") &&
-          dl['arch'] == 'x86_64'
+          dl['arch'] == target_arch
         end
         unless dl
           raise MissingDownloadUrl, "No download for #{arch} for #{version['version']}"

--- a/share/Dockerfile.erb
+++ b/share/Dockerfile.erb
@@ -13,7 +13,7 @@ server_archive_basename = File.basename(server_url)
 server_extracted_dir = server_archive_basename.sub(/\.(tar\.gz|tgz)$/, '')
 
 # When changing, also update the hash in shlib/set_env.sh.
-TOOLCHAIN_VERSION='59927e02080d9fc2578158a6c637e7f99d358656'
+TOOLCHAIN_VERSION='e8c60866f54bed7e336a37df3a97d6ae1b971b7d'
 
 def ruby_toolchain_url(ruby)
   "http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/#{TOOLCHAIN_VERSION}/#{distro}/#{ruby}.tar.xz"

--- a/shlib/server.sh
+++ b/shlib/server.sh
@@ -82,7 +82,7 @@ install_mlaunch_venv() {
     # Debian11/Ubuntu2204 have venv installed, but it is nonfunctional unless
     # the python3-venv package is also installed (it lacks the ensurepip
     # module).
-    sudo apt-get install python3-venv
+    sudo apt-get install --yes python3-venv
   fi
   if test "$USE_SYSTEM_PYTHON_PACKAGES" = 1 &&
     python3 -m pip list |grep mtools

--- a/shlib/server.sh
+++ b/shlib/server.sh
@@ -83,7 +83,7 @@ install_mlaunch_venv() {
     # the python3-venv package is also installed (it lacks the ensurepip
     # module).
     sudo apt-get install python3-venv
-  end
+  fi
   if test "$USE_SYSTEM_PYTHON_PACKAGES" = 1 &&
     python3 -m pip list |grep mtools
   then

--- a/shlib/server.sh
+++ b/shlib/server.sh
@@ -78,6 +78,12 @@ install_mlaunch_venv() {
     # https://github.com/pypa/virtualenv/issues/1630
     python3 -m pip install venv --user
   fi
+  if ! python3 -m ensurepip -h > /dev/null; then
+    # Debian11/Ubuntu2204 have venv installed, but it is nonfunctional unless
+    # the python3-venv package is also installed (it lacks the ensurepip
+    # module).
+    sudo apt-get install python3-venv
+  end
   if test "$USE_SYSTEM_PYTHON_PACKAGES" = 1 &&
     python3 -m pip list |grep mtools
   then

--- a/shlib/server.sh
+++ b/shlib/server.sh
@@ -90,9 +90,14 @@ install_mlaunch_venv() {
     # Use the existing mtools-legacy
     :
   else
-    venvpath="$MONGO_ORCHESTRATION_HOME"/venv
-    python3 -m venv $venvpath
-    . $venvpath/bin/activate
+    # Spawn a virtual environment, but only if one is not already
+    # active...
+    if test -z "$VIRTUAL_ENV"; then
+      venvpath="$MONGO_ORCHESTRATION_HOME"/venv
+      python3 -m venv $venvpath
+      . $venvpath/bin/activate
+    fi
+
     # [mlaunch] does not work:
     # https://github.com/rueckstiess/mtools/issues/856
     # dateutil dependency is missing in mtools: https://github.com/rueckstiess/mtools/issues/864

--- a/shlib/server.sh
+++ b/shlib/server.sh
@@ -164,6 +164,19 @@ install_mlaunch_git() {
   fi
 }
 
+install_cmake() {
+  if ! command -v cmake &> /dev/null; then
+    if ! command -v apt-get &> /dev/null; then
+      # no apt-get; assume RHEL
+      sudo yum -y install cmake libarchive
+    else
+      sudo apt-get install --yes cmake
+    fi
+  else
+    echo 'cmake is present'
+  fi
+}
+
 # This function sets followong global variables:
 #   server_cert_path
 #   server_ca_path

--- a/shlib/set_env.sh
+++ b/shlib/set_env.sh
@@ -1,5 +1,5 @@
 # When changing, also update the hash in share/Dockerfile.
-TOOLCHAIN_VERSION=59927e02080d9fc2578158a6c637e7f99d358656
+TOOLCHAIN_VERSION=e8c60866f54bed7e336a37df3a97d6ae1b971b7d
 
 set_env_java() {
   ls -l /opt || true


### PR DESCRIPTION
This adds changes to support the updated build hosts, including:

* updates to how python is installed on some hosts
* allowing aarch64 database versions to be selected
* adding a helper for installing cmake as needed
* certain build variants might try to create a (python) virtual environment inside an existing virtual environment, which was failing for certain python installations. If a virtual environment is active, we no longer try to create another one.