### PR TITLE
More robust version number parsing

### DIFF
--- a/lib/mrss/lite_constraints.rb
+++ b/lib/mrss/lite_constraints.rb
@@ -98,8 +98,8 @@ module Mrss
     def min_libmongocrypt_version(version)
       require_libmongocrypt
       before(:all) do
-        actual_version = Gem::Version.new(Mongo::Crypt::Binding.mongocrypt_version(nil))
-        min_version = Gem::Version.new(version)
+        actual_version = Utils.parse_version(Mongo::Crypt::Binding.mongocrypt_version(nil))
+        min_version = Utils.parse_version(version)
         unless actual_version >= min_version
           skip "libmongocrypt version #{min_version} required, but version #{actual_version} is available"
         end

--- a/lib/mrss/utils.rb
+++ b/lib/mrss/utils.rb
@@ -3,13 +3,35 @@
 
 module Mrss
   module Utils
+    extend self
 
-    module_function def print_backtrace(dest=STDERR)
-      begin
-        hello world
-      rescue => e
-        dest.puts e.backtrace.join("\n")
-      end
+    def print_backtrace(dest=STDERR)
+      raise
+    rescue => e
+      dest.puts e.backtrace.join("\n")
+    end
+
+    # Parses the given version string, accounting for suffix information that
+    # Gem::Version cannot successfully parse.
+    #
+    # @param [ String ] version the version to parse
+    #
+    # @return [ Gem::Version ] the parsed version
+    #
+    # @raise [ ArgumentError ] if the string cannot be parsed.
+    def parse_version(version)
+      Gem::Version.new(version)
+    rescue ArgumentError
+      match = version.match(/\A(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)?(-[A-Za-z\+\d]+)?\z/)
+      raise ArgumentError.new("Malformed version number string #{version}") if match.nil?
+
+      Gem::Version.new(
+        [
+          match[:major],
+          match[:minor],
+          match[:patch]
+        ].join('.')
+      )
     end
   end
 end


### PR DESCRIPTION
When libmongocrypt gets tagged with a dev version number, the `Gem::Version` object can't parse the version number. This was fixed last year in one place (on `Binding` in the driver), but `spec/shared` also uses `Gem::Version` to validate the libmongocrypt version number. This adds the better parsing there, too.