### PR TITLE
Add platform option for running on apple silicon

### DIFF
--- a/lib/mrss/docker_runner.rb
+++ b/lib/mrss/docker_runner.rb
@@ -210,6 +210,14 @@ module Mrss
       BASE_IMAGES[distro] or raise "Unknown distro: #{distro}"
     end
 
+    def platform
+      if RUBY_PLATFORM =~ /arm64/
+        '--platform=linux/amd64'
+      else
+        nil
+      end
+    end
+
     def ruby
       @env['RVM_RUBY']
     end

--- a/lib/mrss/docker_runner.rb
+++ b/lib/mrss/docker_runner.rb
@@ -196,13 +196,9 @@ module Mrss
       'debian92' => 'debian:stretch',
       'debian10' => 'debian:buster',
       'debian11' => 'debian:bullseye',
-      'ubuntu1404' => 'ubuntu:trusty',
-      'ubuntu1604' => 'ubuntu:xenial',
       'ubuntu1804' => 'ubuntu:bionic',
       'ubuntu2004' => 'ubuntu:focal',
       'ubuntu2204' => 'ubuntu:jammy',
-      'rhel62' => 'centos:6',
-      'rhel70' => 'centos:7',
       'rhel80' => 'rockylinux:8',
     }.freeze
 
@@ -264,14 +260,12 @@ module Mrss
 
     def libmongocrypt_path
       case distro
-      when /ubuntu1604/
-        "./ubuntu1604/nocrypto/lib64/libmongocrypt.so"
       when /ubuntu1804/
         "./ubuntu1804-64/nocrypto/lib64/libmongocrypt.so"
       when /debian92/
         "./debian92/nocrypto/lib64/libmongocrypt.so"
       else
-        raise "This script does not support running FLE tests on #{distro}. Use ubuntu1604, ubuntu1804 or debian92 instead"
+        raise "This script does not support running FLE tests on #{distro}. Use ubuntu1804 or debian92 instead"
       end
     end
 

--- a/share/Dockerfile.erb
+++ b/share/Dockerfile.erb
@@ -1,16 +1,4 @@
-# Python toolchain as of this writing is available on rhel62, debian92 and
-# ubuntu1604.
-#
-# To run rhel62 in docker, host system must be configured to emulate syscalls:
-# https://github.com/CentOS/sig-cloud-instance-images/issues/103
-
 <%
-
-python_toolchain_url = "https://s3.amazonaws.com//mciuploads/mongo-python-driver-toolchain/#{distro}/ba92de2700c04ee2d4f82c3ffdfc33105140cb04/mongo_python_driver_toolchain_#{distro.gsub('-', '_')}_ba92de2700c04ee2d4f82c3ffdfc33105140cb04_19_11_14_15_33_33.tar.gz"
-# server_version = '4.3.3'
-server_url = "http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-#{distro}-#{server_version}.tgz"
-server_archive_basename = File.basename(server_url)
-server_extracted_dir = server_archive_basename.sub(/\.(tar\.gz|tgz)$/, '')
 
 # When changing, also update the hash in shlib/set_env.sh.
 TOOLCHAIN_VERSION='ded7ea845b08cf96f11a747d9540ba3199580dea'
@@ -18,8 +6,6 @@ TOOLCHAIN_VERSION='ded7ea845b08cf96f11a747d9540ba3199580dea'
 def ruby_toolchain_url(ruby)
   "http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/#{TOOLCHAIN_VERSION}/#{distro}/#{ruby}.tar.xz"
 end
-
-#ruby_toolchain_url = "https://s3.amazonaws.com//mciuploads/mongo-ruby-toolchain/#{distro}/#{TOOLCHAIN_VERSION}/mongo_ruby_driver_toolchain_#{distro.gsub('-', '_')}_patch_#{TOOLCHAIN_VERSION}_#{toolchain_lower}.tar.gz"
 
 %>
 
@@ -34,18 +20,6 @@ ENV DOCKER=1
 <% else %>
 
   RUN echo assumeyes=1 |tee -a /etc/yum.conf
-
-<% end %>
-
-<% if ruby_head? %>
-
-  # To use current versions of mlaunch, Python 3.7+ is required.
-  # Many distros ship with older Pythons, therefore we need to install
-  # a newer Python from somewhere. This section installs the Python
-  # toolchain which comes with recent Pythons.
-
-  #RUN curl --retry 3 -fL <%= python_toolchain_url %> -o python-toolchain.tar.gz
-  #RUN tar -xC /opt -zf python-toolchain.tar.gz
 
 <% end %>
 
@@ -80,8 +54,7 @@ ENV DOCKER=1
     procps lsb-release bzip2 curl wget gpg zsh
     git make gcc g++ libyaml-dev libgmp-dev zlib1g-dev libsnappy-dev
     krb5-user krb5-kdc krb5-admin-server libsasl2-dev libsasl2-modules-gssapi-mit
-    haproxy
-    python3-pip
+    haproxy libcurl4 python3-pip ruby bundler
     tzdata shared-mime-info software-properties-common xz-utils nodejs npm
   ) %>
 
@@ -103,22 +76,8 @@ ENV DOCKER=1
 
   <% if distro =~ /debian10|ubuntu2204|debian11/ %>
     <% packages << 'openjdk-11-jdk-headless' %>
-  <% elsif distro =~ /ubuntu1404/ %>
-    # Ubuntu 14.04 only has openjdk 7, this is too old to be useful
   <% else %>
     <% packages << 'openjdk-8-jdk-headless' %>
-  <% end %>
-
-  # ubuntu1404, ubuntu1604: libcurl3
-  # ubuntu1804, ubuntu2004, debian10: libcurl4
-  <% if distro =~ /ubuntu1804|ubuntu2004|ubuntu2204|debian10|debian11/ %>
-    <% packages << 'libcurl4' %>
-  <% else %>
-    <% packages << 'libcurl3' %>
-  <% end %>
-
-  <% if distro =~ /ubuntu2004|ubuntu2204/ %>
-    <% packages += %w(ruby bundler) %>
   <% end %>
 
   RUN apt-get update && apt-get install -y <%= packages.join(' ') %>
@@ -130,29 +89,6 @@ ENV DOCKER=1
   RUN apt-get update && apt-get install -y cmake
 
 <% else %>
-
-  <% if distro =~ /rhel6/ %>
-
-    # CentOS 6 is dead - to use it retrieve the packages from vault:
-    # https://stackoverflow.com/questions/53562691/error-cannot-retrieve-repository-metadata-repomd-xml-for-repository-base-pl
-
-    <%
-
-      cfg = <<-CFG
-[base]
-name=CentOS-$releasever - Base
-#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
-baseurl=http://vault.centos.org/6.10/os/x86_64/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-CFG
-
-    %>
-
-    RUN printf "<%= cfg.gsub("\n", "\\n") %>" >/etc/yum.repos.d/CentOS-Base.repo
-
-  <% end %>
 
   # Enterprise server: net-snmp
   # lsb_release: redhat-lsb-core
@@ -176,7 +112,7 @@ CFG
 
 <% if preload? %>
 
-  <% if distro =~ /debian9|ubuntu1604|ubuntu1804/ %>
+  <% if distro =~ /debian9|ubuntu1804/ %>
     # Install python 3.7 for mlaunch.
     RUN curl -fL --retry 3 https://github.com/p-mongodb/deps/raw/main/<%= distro %>-python37.tar.xz | \
       tar xfJ - -C /opt
@@ -184,16 +120,8 @@ CFG
     RUN python3 -V
   <% end %>
 
-  <% if true || distro =~ /rhel|ubuntu1604/ %>
+  <% if true || distro =~ /rhel/ %>
 
-    # Ubuntu 12.04 ships pip 1.0 which is ancient and does not work.
-    #
-    # Ubuntu 16.04 apparently also ships a pip that does not work:
-    # https://stackoverflow.com/questions/37495375/python-pip-install-throws-typeerror-unsupported-operand-types-for-retry
-    # Potentially this only affects environments with less than ideal
-    # connectivity (or, perhaps, when python package registry is experiencing
-    # availability issues) when pip must retry to install packages.
-    #
     # rhel apparently does not package pip at all in core repoitories,
     # therefore install it the manual way.
     #
@@ -203,48 +131,25 @@ CFG
 
   <% end %>
 
-  # Current virtualenv fails with
-  # https://github.com/pypa/virtualenv/issues/1630
-  <% mtools = 'legacy' %>
-  <% case mtools
-     when 'legacy' %>
-    # dateutil dependency is missing in mtools: https://github.com/rueckstiess/mtools/issues/864
-    RUN python3 -m pip install 'virtualenv<20' 'mtools-legacy[mlaunch]' 'pymongo<4' python-dateutil
-  <% when 'git' %>
-    # dateutil dependency is missing in mtools: https://github.com/rueckstiess/mtools/issues/864
-    RUN python3 -m pip install virtualenv 'pymongo>=4' python-dateutil psutil
-
-    # Install mtools from git because released versions do not work with pymongo 4.0
-    RUN git clone https://github.com/p-mongodb/mtools && \
-      cd mtools && \
-      python3 setup.py install
-  <% else %>
-    # mtools[mlaunch] does not work: https://github.com/rueckstiess/mtools/issues/856
-    # dateutil dependency is missing in mtools: https://github.com/rueckstiess/mtools/issues/864
-    RUN python3 -m pip install virtualenv 'pymongo>=4' python-dateutil psutil mtools
-  <% end %>
+  # mtools[mlaunch] does not work: https://github.com/rueckstiess/mtools/issues/856
+  # dateutil dependency is missing in mtools: https://github.com/rueckstiess/mtools/issues/864
+  RUN python3 -m pip install virtualenv 'pymongo>=4' python-dateutil psutil mtools
 
   <% if @env.fetch('MONGODB_VERSION') >= '4.4' %>
-    # ubuntu1604 installs MarkupSafe 0.0.0 here instead of 2.0.0+
-    # as specified by dependencies, causing OCSP mock to not work.
     RUN python3 -mpip install asn1crypto oscrypto flask --upgrade --ignore-installed
   <% end %>
 
-  # FLE is tested against 4.0+ servers.
-  <% if @env.fetch('MONGODB_VERSION') >= '4.0' %>
-    # Requirements in drivers-evergreen-tools:
-    # boto3~=1.19 cryptography~=3.4.8 pykmip~=0.10.0
-    # cryptography does not install due to lacking setuptools_rust
-    # (either that version or anything that isn't part of system packages)
-    RUN python3 -mpip install boto3~=1.19 cryptography pykmip~=0.10.0 'sqlalchemy<2.0.0'
-  <% end %>
+  # Requirements in drivers-evergreen-tools:
+  # boto3~=1.19 cryptography~=3.4.8 pykmip~=0.10.0
+  # cryptography does not install due to lacking setuptools_rust
+  # (either that version or anything that isn't part of system packages)
+  RUN python3 -mpip install boto3~=1.19 cryptography pykmip~=0.10.0 'sqlalchemy<2.0.0'
 
   <% unless ruby_head? || system_ruby? %>
 
     RUN curl --retry 3 -fL <%= ruby_toolchain_url(ruby) %> |tar -xC /opt -Jf -
     ENV PATH=/opt/rubies/<%= ruby %>/bin:$PATH \
       USE_OPT_TOOLCHAIN=1
-    #ENV PATH=/opt/rubies/python/3/bin:$PATH
 
   <% end %>
 

--- a/share/Dockerfile.erb
+++ b/share/Dockerfile.erb
@@ -23,7 +23,7 @@ end
 
 %>
 
-FROM <%= base_image %>
+FROM <%= platform %> <%= base_image %>
 
 ENV DOCKER=1
 


### PR DESCRIPTION
Running `.evergreen/test-on-docker` doesn't work on M1/M2 machines, because the setup currently expects the host machine to be an intel architecture. This PR adds an appropriate `--platform` option to the Dockerfile if the host is an `arm64` architecture, which is enough to (mostly) run the docker test script.
