### PR TITLE
Updating the toolchain version variable to reflect the latest changes to mongo-ruby-toolchain

### DIFF
--- a/share/Dockerfile.erb
+++ b/share/Dockerfile.erb
@@ -13,7 +13,7 @@ server_archive_basename = File.basename(server_url)
 server_extracted_dir = server_archive_basename.sub(/\.(tar\.gz|tgz)$/, '')
 
 # When changing, also update the hash in shlib/set_env.sh.
-TOOLCHAIN_VERSION='ded7ea845b08cf96f11a747d9540ba3199580dea'
+TOOLCHAIN_VERSION='c950fe1e85fd7d5e4ea69cc2afff456825583716'
 
 def ruby_toolchain_url(ruby)
   "http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/#{TOOLCHAIN_VERSION}/#{distro}/#{ruby}.tar.xz"

--- a/shlib/set_env.sh
+++ b/shlib/set_env.sh
@@ -1,5 +1,5 @@
 # When changing, also update the hash in share/Dockerfile.
-TOOLCHAIN_VERSION=ded7ea845b08cf96f11a747d9540ba3199580dea
+TOOLCHAIN_VERSION=c950fe1e85fd7d5e4ea69cc2afff456825583716
 JDK_VERSION=jdk17
 
 set_env_java() {


### PR DESCRIPTION
To add support for ruby-3.3