### PR TITLE
Detect amazon2 distro

### DIFF
--- a/shlib/distro.sh
+++ b/shlib/distro.sh
@@ -64,6 +64,16 @@ _detect_distro() {
       release=`echo $release |sed -e s/7/70/ -e s/6/62/ -e s/8/80/`
       distro=rhel$release
     fi
+  elif test -f /etc/os-release; then
+    name=`grep -o '^NAME=.*' /etc/os-release | awk -F '"' '{ print $2 }'`
+    version=`grep -o '^VERSION=.*' /etc/os-release | awk -F '"' '{ print $2 }'`
+    if test "$name" = "Amazon Linux"; then
+      distro=amazon$version
+    else
+      cat /etc/os-release
+      echo 'Unknown distro' 1>&2
+      exit 1
+    fi
   else
     lsb_release -a
     echo 'Unknown distro' 1>&2


### PR DESCRIPTION
The `host_distro` function does not currently detect the `amazon2` distro, which causes one of our ruby builds to fail. This adds logic for detecting it.