### PR TITLE
RUBY-3598 Use simplified toolchain

### DIFF
--- a/share/Dockerfile.erb
+++ b/share/Dockerfile.erb
@@ -1,25 +1,8 @@
-# Python toolchain as of this writing is available on rhel62, debian92 and
-# ubuntu1604.
-#
-# To run rhel62 in docker, host system must be configured to emulate syscalls:
-# https://github.com/CentOS/sig-cloud-instance-images/issues/103
-
 <%
 
-python_toolchain_url = "https://s3.amazonaws.com//mciuploads/mongo-python-driver-toolchain/#{distro}/ba92de2700c04ee2d4f82c3ffdfc33105140cb04/mongo_python_driver_toolchain_#{distro.gsub('-', '_')}_ba92de2700c04ee2d4f82c3ffdfc33105140cb04_19_11_14_15_33_33.tar.gz"
-# server_version = '4.3.3'
-server_url = "http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-#{distro}-#{server_version}.tgz"
-server_archive_basename = File.basename(server_url)
-server_extracted_dir = server_archive_basename.sub(/\.(tar\.gz|tgz)$/, '')
-
-# When changing, also update the hash in shlib/set_env.sh.
-TOOLCHAIN_VERSION='deefab59d8f539bdd4a0154505f1e7d39a0857d0'
-
 def ruby_toolchain_url(ruby)
-  "http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/#{TOOLCHAIN_VERSION}/#{distro}/#{ruby}.tar.xz"
+  "http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/library/#{distro}/#{ruby}.tar.xz"
 end
-
-#ruby_toolchain_url = "https://s3.amazonaws.com//mciuploads/mongo-ruby-toolchain/#{distro}/#{TOOLCHAIN_VERSION}/mongo_ruby_driver_toolchain_#{distro.gsub('-', '_')}_patch_#{TOOLCHAIN_VERSION}_#{toolchain_lower}.tar.gz"
 
 %>
 
@@ -34,18 +17,6 @@ ENV DOCKER=1
 <% else %>
 
   RUN echo assumeyes=1 |tee -a /etc/yum.conf
-
-<% end %>
-
-<% if ruby_head? %>
-
-  # To use current versions of mlaunch, Python 3.7+ is required.
-  # Many distros ship with older Pythons, therefore we need to install
-  # a newer Python from somewhere. This section installs the Python
-  # toolchain which comes with recent Pythons.
-
-  #RUN curl --retry 3 -fL <%= python_toolchain_url %> -o python-toolchain.tar.gz
-  #RUN tar -xC /opt -zf python-toolchain.tar.gz
 
 <% end %>
 
@@ -206,7 +177,6 @@ ENV DOCKER=1
     RUN curl --retry 3 -fL <%= ruby_toolchain_url(ruby) %> |tar -xC /opt -Jf -
     ENV PATH=/opt/rubies/<%= ruby %>/bin:$PATH \
       USE_OPT_TOOLCHAIN=1
-    #ENV PATH=/opt/rubies/python/3/bin:$PATH
 
   <% end %>
 

--- a/shlib/set_env.sh
+++ b/shlib/set_env.sh
@@ -1,5 +1,4 @@
 # When changing, also update the hash in share/Dockerfile.
-TOOLCHAIN_VERSION=deefab59d8f539bdd4a0154505f1e7d39a0857d0
 JDK_VERSION=jdk17
 
 set_env_java() {
@@ -90,34 +89,13 @@ set_env_ruby() {
     if test "$USE_OPT_TOOLCHAIN" = 1; then
       # Nothing, also PATH is already set
       :
-    elif true; then
-
-    # For testing toolchains:
-    #toolchain_url=https://s3.amazonaws.com//mciuploads/mongo-ruby-toolchain/`host_distro`/f11598d091441ffc8d746aacfdc6c26741a3e629/mongo_ruby_driver_toolchain_`host_distro |tr - _`_patch_f11598d091441ffc8d746aacfdc6c26741a3e629_5e46f2793e8e866f36eda2c5_20_02_14_19_18_18.tar.gz
-    toolchain_url=http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/$TOOLCHAIN_VERSION/`host_distro`/$RVM_RUBY.tar.xz
-    curl --retry 3 -fL $toolchain_url |tar Jxf -
-    export PATH=`pwd`/rubies/$RVM_RUBY/bin:$PATH
-    #export PATH=`pwd`/rubies/python/3/bin:$PATH
-
-    # Attempt to get bundler to report all errors - so far unsuccessful
-    #curl --retry 3 -o bundler-openssl.diff https://github.com/bundler/bundler/compare/v2.0.1...p-mongo:report-errors.diff
-    #find . -path \*/lib/bundler/fetcher.rb -exec patch {} bundler-openssl.diff \;
-
     else
+      # For testing unpublished builds:
+      #build_url=https://s3.amazonaws.com/mciuploads/mongo-ruby-toolchain/library/`host_distro`/$RVM_RUBY.tar.xz
 
-    # Normal operation
-    if ! test -d $HOME/.rubies/$RVM_RUBY/bin; then
-      echo "Ruby directory does not exist: $HOME/.rubies/$RVM_RUBY/bin" 1>&2
-      echo "Contents of /opt:" 1>&2
-      ls -l /opt 1>&2 || true
-      echo ".rubies symlink:" 1>&2
-      ls -ld $HOME/.rubies 1>&2 || true
-      echo "Our rubies:" 1>&2
-      ls -l $HOME/.rubies 1>&2 || true
-      exit 2
-    fi
-    export PATH=$HOME/.rubies/$RVM_RUBY/bin:$PATH
-
+      build_url=http://boxes.10gen.com/build/toolchain-drivers/mongo-ruby-driver/library/`host_distro`/$RVM_RUBY.tar.xz
+      curl --retry 3 -fL $build_url |tar Jxf -
+      export PATH=`pwd`/rubies/$RVM_RUBY/bin:$PATH
     fi
 
     ruby --version
@@ -128,19 +106,5 @@ set_env_ruby() {
 
     ruby -v |fgrep $ruby_name
     ruby -v |fgrep $ruby_version
-
-    # We shouldn't need to update rubygems, and there is value in
-    # testing on whatever rubygems came with each supported ruby version
-    #echo 'updating rubygems'
-    #gem update --system
-
-    # Only install bundler when not using ruby-head.
-    # ruby-head comes with bundler and gem complains
-    # because installing bundler would overwrite the bundler binary.
-    # We now install bundler in the toolchain, hence nothing needs to be done
-    # in the tests.
-    if false && echo "$RVM_RUBY" |grep -q jruby; then
-      gem install bundler -v '<2'
-    fi
   fi
 }


### PR DESCRIPTION
The DBX-Ruby toolchain builder no longer prefixes each Ruby build with the corresponding commit SHA, and instead just puts them all in a common `library` directory. (See RUBY-3598 for details.)

This PR modifies the spec/shared code so that it pulls the appropriate Ruby build from that `library` directory, instead of looking for a build under an arbitrary commit SHA. This will make it much easier to match Ruby builds to distros whenever it is necessary to change the distro that is used to run tests.