### PR TITLE
RUBY-3643 Add logic for generating pull requests for new releases

### DIFF
--- a/lib/mrss/release/candidate.rb
+++ b/lib/mrss/release/candidate.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative 'product_data'
+
+module Mrss
+  module Release
+    class Candidate
+      # Release note section titles, by pr type
+      SECTION_TITLE = {
+        bcbreak: "Breaking Changes",
+        feature: "New Features",
+        bug: "Bug Fixes",
+      }.freeze
+
+      # GitHub labels
+      BCBREAK = 'bcbreak'
+      FEATURE = 'feature'
+      BUG = 'bug'
+      PATCH = 'patch'
+
+      def self.instance
+        @instance ||= new
+
+        yield @instance if block_given?
+
+        @instance
+      end
+
+      def product
+        @product ||= ProductData.new
+      end
+
+      def bump_version
+        product.bump_version(release_type)
+      end
+
+      def bump_version!
+        product.bump_version!(release_type)
+      end
+
+      def branch_name
+        @branch_name ||= "rc-#{product.version}"
+      end
+
+      # return a string of commit names since the last release
+      def pending_changes
+        @changes ||= begin
+                       range = product.tag_exists? ? "#{product.tag_name}.." : ""
+                       `git log --pretty=format:"%s" #{range}`
+                     end
+      end
+
+      # return a list of PR numbers since the last release
+      def pending_pr_numbers
+        @pending_pr_numbers ||= pending_changes.
+          lines.
+          map { |line| line.match(/\(#(\d+)\)$/).then { |m| m && m[1] } }.
+          compact.
+          sort.reverse
+      end
+
+      # return a JSON string of PR data
+      def pending_pr_dump
+        @pending_pr_dump ||= `gh pr list --state all --limit 256 --json number,title,labels,url,body --jq 'map(select([.number] | inside([#{pending_pr_numbers.join(',')}]))) | sort_by(.number)'`
+      end
+
+      # return a list of PR data since the last release
+      def pending_prs
+        @pending_prs ||= JSON.parse(pending_pr_dump)
+      end
+
+      # return a list of pending prs with additional attributes (summary,
+      # short title, jira issue number).
+      def decorated_prs
+        @decorated_prs ||= pending_prs.map do |pr|
+                             jira_issue, pr_title = split_pr_title(pr)
+                             summary = extract_summary(pr)
+                             type = pr_type(pr)
+                             type_code = pr_type_code(type)
+                             patch_flag = pr_patch_flag?(pr)
+
+                             pr.merge('jira' => jira_issue,
+                                      'short-title' => pr_title,
+                                      'summary' => summary,
+                                      'type' => type,
+                                      'type-code' => type_code,
+                                      'patch' => patch_flag)
+                           end
+      end
+
+      # return a hash of decorated prs grouped by :bcbreak, :feature, or :bug
+      def prs_by_type
+        @prs_by_type ||= decorated_prs.group_by { |pr| pr['type'] }
+      end
+
+      # returns 'major', 'minor', or 'patch', depending on the presence of
+      # (respectively) :bcbreak, :feature, or :bug labels.
+      #
+      # If the RELEASE environment variable is set, its value will be used
+      # directly, ignoring whatever PR labels might exist.
+      def release_type
+        @release_type ||= if ENV['RELEASE']
+                            ENV['RELEASE']
+                          elsif prs_by_type[:bcbreak]
+                            'major'
+                          elsif prs_by_type[:feature] && prs_by_type[:feature].any? { |pr| !pr['patch'] }
+                            'minor'
+                          else
+                            'patch'
+                          end
+      end
+
+      # returns the generated release notes as a string
+      def release_notes
+        @release_notes ||= release_notes_intro +
+          %i[ bcbreak feature bug ].
+            flat_map { |type| release_notes_for_type(type) }.join("\n")
+      end
+
+      private
+
+      # returns an array of strings, each string representing a single line
+      # in the release notes for the PR's of the given type.
+      def release_notes_for_type(type)
+        return [] unless prs_by_type[type]
+
+        [].tap do |lines|
+          lines << "\# #{SECTION_TITLE[type]}"
+          lines << ''
+
+          prs = prs_by_type[type]
+          summarized, unsummarized = prs.partition { |pr| pr['summary'] }
+
+          summarized.each do |pr|
+            header = [ '### ' ]
+            header << "[#{pr['jira']}](#{jira_url(pr['jira'])}) " if pr['jira']
+            header << "#{pr['short-title']} ([PR](#{pr['url']}))"
+            lines << header.join
+            lines << ''
+            lines << pr['summary']
+            lines << ''
+          end
+
+          if summarized.any? && unsummarized.any?
+            lines << ''
+            lines << [ '### Other ', SECTION_TITLE[type] ].join
+            lines << ''
+          end
+
+          unsummarized.each do |pr|
+            line = [ '* ' ]
+            line << "[#{pr['jira']}](#{jira_url(pr['jira'])}) " if pr['jira']
+            line << "#{pr['short-title']} ([PR](#{pr['url']}))"
+
+            lines << line.join
+          end
+
+          lines << ''
+        end
+      end
+
+      # returns the URL of for the given jira issue
+      def jira_url(issue)
+        "https://jira.mongodb.org/browse/#{issue}"
+      end
+
+      # assumes a pr title in the format of "JIRA-1234 PR Title (#1234)",
+      # returns a tuple of [ jira-issue, title ], where jira-issue may be
+      # blank (if no jira issue is in the title).
+      def split_pr_title(pr)
+        title = pr['title'].gsub(/\(#\d+\)/, '').strip
+
+        if title =~ /^(\w+-\d+) (.*)$/
+          [ $1, $2 ]
+        else
+          [ nil, title ]
+        end
+      end
+
+      # extracts the summary section from the pr and returns it (or returns nil
+      # if no summary section is detected)
+      def extract_summary(pr)
+        summary = []
+        accumulating = false
+        level = nil
+
+        pr['body'].lines.each do |line|
+          # a header of any level titled "summary" will begin the summary
+          if !accumulating && line =~ /^(\#+)\s+summary\s+$/i
+            accumulating = true
+            level = $1.length
+
+          # a header of any level less than or equal to the summary header's
+          # level will end the summary
+          elsif accumulating && line =~ /^\#{1,#{level}}\s+/
+            break
+
+          # otherwise, the line is part of the summary
+          elsif accumulating
+            summary << line
+          end
+        end
+
+        summary.any? ? summary.join.strip : nil
+      end
+
+      # Returns a symbol (:bcbreak, :feature, or :bug) that identifies the
+      # type of this PR that would most strongly influence what type of release
+      # it requires.
+      def pr_type(pr)
+        if pr['labels'].any? { |l| l['name'] == BCBREAK }
+          :bcbreak
+        elsif pr['labels'].any? { |l| l['name'] == FEATURE }
+          :feature
+        elsif pr['labels'].any? { |l| l['name'] == BUG }
+          :bug
+        else
+          nil
+        end
+      end
+
+      # `true` if the `patch` label is applied to the PR. This is used to
+      # indicate that a "feature" PR should be treated as a patch, for
+      # determining the release type only.
+      def pr_patch_flag?(pr)
+        pr['labels'].any? { |l| l['name'] == PATCH }
+      end
+
+      def pr_type_code(type)
+        case type
+        when :bcbreak then 'x'
+        when :feature then 'f'
+        when :bug     then 'b'
+        else '?'
+        end
+      end
+
+      # Return a string containing the markdown-formatted intro block for
+      # the release notes of this candidate.
+      def release_notes_intro
+        <<~INTRO
+          #{product.name} #{product.version} is a new #{release_type} release.
+
+          Install it via RubyGems at a command-line:
+
+          ~~~
+          gem install -v #{product.version} #{product.package}
+          ~~~
+
+          Or by adding it to your Gemfile:
+
+          ~~~
+          gem '#{product.package}', '#{product.version}'
+          ~~~
+
+          Notable changes in this release are:
+
+        INTRO
+      end
+    end
+  end
+end

--- a/lib/mrss/release/product_data.rb
+++ b/lib/mrss/release/product_data.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Mrss
+  module Release
+    class ProductData
+      FILE_PATH = 'product.yml'
+
+      def self.init!
+        if File.exist?(FILE_PATH)
+          raise "#{FILE_PATH} already exists; refusing to overwrite it"
+        end
+
+        initial_data = {
+          'name' => 'Product Name',
+          'package' => 'product_package',
+          'version' => { 'number' => '1.0.0',
+                         'file' => 'path/to/version.rb' }
+        }
+
+        File.write(FILE_PATH, initial_data.to_yaml)
+      end
+
+      def initialize
+        @hash = YAML.load_file(FILE_PATH)
+      end
+
+      def save_product_file!
+        File.write(FILE_PATH, @hash.to_yaml)
+      end
+
+      def rewrite_version_file!
+        version_module = File.read(version_file)
+        new_module = version_module.
+          sub(/^(\s*)(VERSION\s*=\s*).*$/) { "#{$1}#{$2}#{version.inspect}" }
+        File.write(version_file, new_module)
+      end
+
+      def version
+        @hash['version']['number']
+      end
+
+      def version=(number)
+        @hash['version']['number'] = number
+      end
+
+      # returns an array of [ major, minor, patch, suffix ].
+      #
+      # each element will be returned as a String.
+      def version_parts
+        version.split(/\./, 4)
+      end
+
+      # bump the version according to the given release type:
+      #
+      #  'major' -> increment major component, zero the others
+      #  'minor' -> increment minor component, zero the patch
+      #  'patch' -> increment the patch component
+      def bump_version(release)
+        major, minor, patch, suffix = version_parts
+
+        case release
+        when 'major' then
+          major = major.to_i + 1
+          minor = patch = 0
+        when 'minor'
+          minor = minor.to_i + 1
+          patch = 0
+        when 'patch'
+          patch = patch.to_i + 1
+        else
+          raise ArgumentError, "invalid release type: #{release.inspect}"
+        end
+
+        self.version = [ major, minor, patch ].join('.')
+      end
+
+      # Invokes `#bump_version`, and then saves the new version to the
+      # product.yml file and to the version.rb file.
+      def bump_version!(release)
+        bump_version(release)
+        save_product_file!
+        rewrite_version_file!
+      end
+
+      def version_file
+        @hash['version']['file']
+      end
+
+      def name
+        @hash['name']
+      end
+
+      def package
+        @hash['package']
+      end
+
+      def tag_name
+        "v#{version}"
+      end
+
+      def tag_exists?(tag = tag_name)
+        `git tag -l #{tag}`.strip == tag
+      end
+
+      def branch_exists?(branch)
+        `git branch -l #{branch}`.strip == branch
+      end
+
+      def base_branch
+        @base_branch ||= begin
+                           major, minor, = version_parts
+                           branch = "#{major}.#{minor}-stable"
+                           branch_exists?(branch) ? branch : 'master'
+                         end
+      end
+    end
+  end
+end

--- a/lib/tasks/candidate.rake
+++ b/lib/tasks/candidate.rake
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../mrss/release/candidate'
+
+namespace :candidate do
+  desc 'Initialize a new product.yml file'
+  task :init do
+    Mrss::Release::ProductData.init!
+    puts "product.yml file created"
+  end
+
+  desc 'Print the release notes for the next candidate release'
+  task :preview do
+    Mrss::Release::Candidate.instance do |candidate|
+      # load the pending changes before bumping the version, since it
+      # depends on the value of the current version.
+      candidate.pending_changes
+      candidate.bump_version
+      puts candidate.release_notes
+    end
+  end
+
+  desc 'List the pull requests to be included in the next release'
+  task :prs do
+    Mrss::Release::Candidate.instance.decorated_prs.each do |pr|
+      print "\##{pr['number']}[#{pr['type-code']}] "
+      print "#{pr['jira']} " if pr['jira']
+      puts pr['short-title']
+    end
+  end
+
+  desc 'Create a new branch and pull request for the candidate'
+  task create: :check_branch_status do
+    Mrss::Release::Candidate.instance do |candidate|
+      origin = `git config get remote.origin.url`
+      match = origin.match(/:(.*?)\//) or raise "origin url is not in expected format: #{origin.inspect}"
+      user = match[1]
+
+      puts 'gathering candidate info and bumping version...'
+      candidate.bump_version!
+
+      puts 'writing release notes to /tmp/pr-body.md...'
+      File.write('/tmp/pr-body.md', candidate.release_notes)
+
+      sh 'git', 'checkout', '-b', candidate.branch_name
+      sh 'git', 'commit', '-am', "Bump version to #{candidate.product.version}"
+      sh 'git', 'push', 'origin', candidate.branch_name
+
+      sh 'gh', 'pr', 'create',
+           '--head', "#{user}:#{candidate.branch_name}",
+           '--base', candidate.product.base_branch,
+           '--title', "Release candidate for #{candidate.product.version}",
+           '--label', 'release-candidate',
+           '--body-file', '/tmp/pr-body.md'
+    end
+  end
+
+  # Ensures the current branch is up-to-date with no uncommitted changes
+  task :check_branch_status do
+    sh 'git pull >/dev/null', verbose: false
+    changes = `git status --short --untracked-files=no`.strip
+    abort "There are uncommitted changes. Commit (or revert) the changes and try again." if changes.length > 0
+  end
+end


### PR DESCRIPTION
As part of RUBY-3643, this PR adds a new rake namespace and assorted tasks that may be included in the Rakefiles of other products. Of particular note is the `candidate:create` task, which creates a new branch, bumps the version number, and creates a pull request with its description pre-populated with the autogenerated release notes for the next release of the product.