### PR TITLE
Set JDK to 21

### DIFF
--- a/shlib/set_env.sh
+++ b/shlib/set_env.sh
@@ -1,5 +1,5 @@
 # When changing, also update the hash in share/Dockerfile.
-JDK_VERSION=jdk17
+JDK_VERSION=jdk21
 
 set_env_java() {
   ls -l /opt || true


### PR DESCRIPTION
We need JDK 21 for jruby 10.
This is tested with the toolchain - https://github.com/10gen/mongo-ruby-toolchain/pull/51